### PR TITLE
Add the AABB fields in the key of meshes

### DIFF
--- a/AssetRipper.Mining.PredefinedAssets/AxisAlignedBoundingBox.cs
+++ b/AssetRipper.Mining.PredefinedAssets/AxisAlignedBoundingBox.cs
@@ -1,0 +1,5 @@
+using System.Numerics;
+
+namespace AssetRipper.Mining.PredefinedAssets;
+
+public record struct AxisAlignedBoundingBox(Vector3 Center, Vector3 Extents);

--- a/AssetRipper.Mining.PredefinedAssets/Mesh.cs
+++ b/AssetRipper.Mining.PredefinedAssets/Mesh.cs
@@ -4,15 +4,17 @@ public sealed record class Mesh : NamedObject
 {
 	public required int VertexCount { get; init; }
 	public required int SubMeshCount { get; init; }
+	public required AxisAlignedBoundingBox LocalAABB { get; init; }
 
 	public Mesh()
 	{
 	}
 
 	[SetsRequiredMembers]
-	public Mesh(string name, int vertexCount, int subMeshCount) : base(name)
+	public Mesh(string name, int vertexCount, int subMeshCount, AxisAlignedBoundingBox localAabb) : base(name)
 	{
 		VertexCount = vertexCount;
 		SubMeshCount = subMeshCount;
+		LocalAABB = localAabb;
 	}
 }


### PR DESCRIPTION
Adds the aabb float fields into the mesh key.

This is the first part to fix the key not being exhaustive enough.